### PR TITLE
GLM-9099 - Bump version of omniauth-oauth2

### DIFF
--- a/omniauth-amazon.gemspec
+++ b/omniauth-amazon.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'omniauth-oauth2', '~> 1.7.1'
+  spec.add_dependency 'omniauth-oauth2', '~> 1.8'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
To fulfill this [linear task](https://linear.app/gleamio/issue/GLM-9099), the following steps are required. And this is one of two PRs that are required to complete this task.

For a bit more context, to apply the [new granular permissions requirement](https://developers.google.com/identity/protocols/oauth2/resources/granular-permissions), it is necessary to update omniauth-google-oauth2 to its latest version [1.1.2](https://github.com/zquestz/omniauth-google-oauth2/releases/tag/v1.1.2) on the main Gleam repo. However, this version update also has another gem dependency [omniauth-oauth2 version 1.8](https://github.com/zquestz/omniauth-google-oauth2/blob/master/omniauth-google-oauth2.gemspec#L26), that causes a few gem conflicts.

Therefore, a bump in `omniauth-oauth2` to version 1.8 in this gem is also required.